### PR TITLE
ふぁぼボタンが横に広がっていたのを修正 & いらないタグを削除

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -86,8 +86,6 @@
             <small-tweet v-if="body(tweet).in_reply_to_status && isSelectedTweet(tweet)"
                         :tweet="body(tweet).in_reply_to_status" :replysender="false">
             </small-tweet>
-            <div>
-              <span v-on:click="favoriteTweet(body(tweet))">
             <div class="infobar">
               <div class="favorite" v-on:click="favoriteTweet(body(tweet))">
                 <span v-if="body(tweet).favorited">🍣</span>
@@ -106,7 +104,6 @@
               </div>
             </div>
           </div>
-
         </li>
       </ul>
     </div>

--- a/app/index.html
+++ b/app/index.html
@@ -88,8 +88,8 @@
             </small-tweet>
             <div class="infobar">
               <div class="favorite" v-on:click="favoriteTweet(body(tweet))">
-                <span v-if="body(tweet).favorited">🍣</span>
-                <span v-else>🍚</span>
+                <span v-if="body(tweet).favorited">{{{ '🍣' | twemoji }}}</span>
+                <span v-else>{{{ '🍚' | twemoji }}}</span>
                 {{ body(tweet).favorite_count }}
               </div>
               <div class="spacing"></div>


### PR DESCRIPTION
クリックするとふぁぼれる `span` タグが残ってしまっていた。
ついでになくてよい `div` タグも削除。
